### PR TITLE
Abandoned decorator bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,6 @@
         "symfony/security": "~3 | ~4",
         "symfony/config": "~3 | ~4",
         "php": "~7.1"
-    }
+    },
+    "abandoned": true
 }


### PR DESCRIPTION
[INGIANA-16](https://issues.internations.org/browse/INGIANA-16) Sunset public package internations/decorator-bundle, and move it as deprecated into our codebase.
This bundle should be removed when we switch to the Symfony messenger component.

More details:
https://www.php.net/manual/en/function.array-unique.php
The behaviour change of array_unique from php74. to 8 could introduces bugs depending on how you configured your decorators. It could result in a different order of the decorators. For us it does not make a difference, but it would be nonsense to provide 8.1 support for the public repo.